### PR TITLE
Changes to update nics-common dependencies to 2018

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>com.tabordasolutions.nics.common</groupId>
             <artifactId>rabbitmq-client</artifactId>
-            <version>2018.1</version>
+            <version>2018.1.3</version>
         </dependency>
 
       


### PR DESCRIPTION
##What is changed
Update nics dependencies version to 2018.1